### PR TITLE
Add missing import to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Just like a regular `cachetools.Cache`, the `PersistentCache` can be used with
 `cachetools`' `cached` decorator:
 
 ```python
+import cachetools
 from shelved_cache import PersistentCache
 from cachetools import LRUCache
 


### PR DESCRIPTION
(This is required for the `cachetools.cached` call in the example.)