### PR TITLE
docs: add type hints for filename to include os.PathLike

### DIFF
--- a/shelved_cache/persistent_cache.py
+++ b/shelved_cache/persistent_cache.py
@@ -61,7 +61,11 @@ class PersistentCache(MutableMapping):
     """
 
     def __init__(
-        self, wrapped_cache_cls: Type[Cache], filename: str, *args, **kwargs
+        self,
+        wrapped_cache_cls: Type[Cache],
+        filename: str | os.PathLike[str],
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         new_cls = type(
             f"Wrapped{wrapped_cache_cls.__name__}", (DelMixin, wrapped_cache_cls), {}


### PR DESCRIPTION
This change will prevent a type checker from detecting an incorrect data type when using this library.

For example (a `Path` is being provided as an argument):
<img width="597" height="61" alt="Captura de pantalla 2025-07-30 a la(s) 2 40 59 p m" src="https://github.com/user-attachments/assets/67548eca-c813-46cf-9ed6-5b2f0ba599a8" />

Currently, this is the quick solution to avoid this problem:
<img width="624" height="79" alt="Captura de pantalla 2025-07-30 a la(s) 2 42 24 p m" src="https://github.com/user-attachments/assets/f78892bb-a25b-4556-8268-e5a76a6bfb85" />

Anyway, it is expected that when a `Path` instance is provided, there should be no major problem. This can be further improved by including typing in this way:

```python
filename: str | bytes | os.PathLike[str] | os.PathLike[bytes]
```

Let me know if you want to include this change.